### PR TITLE
[ENH] add authorship agreement

### DIFF
--- a/brainhack_book/authorship-agreement.md
+++ b/brainhack_book/authorship-agreement.md
@@ -1,0 +1,107 @@
+# Authorship agreement
+
+In this document we describe the contribution and authorship guidelines for the
+Brainhack Neuro view paper that we collectively agreed on. 
+Specifically, we try
+to describe the motivations and processes used to define the different levels of
+contributions for this project.
+
+For us it is important that nobody in the Brainhack community is excluded and we
+want to recognize that this community and what it has created is the result of a
+collective effort: we wanted our author list to recognize this and to be as
+inclusive as possible — e.g. having contributed by organizing an event is a
+sufficient condition to be an author. 
+Nevertheless, based on the huge amount of
+people and their different input on this paper, we also agreed to define several
+different groups with minimal conditions for each. 
+Please note that the
+authorship decisions described here were confirmed by majority vote open to all
+participants on Sept. 26 2020.
+
+We used a form where each person could add their name, affiliation(s), contact
+details AND explicitly describe their contribution either by ticking boxes from
+a list of tasks and/or by giving a written description of what they did (this
+approach was in part inspired by the contribution system used by the Turing way
+project). 
+The contributors spreadsheet resulting from this form was then used to
+help us divide authors into core-team and non-core-team members and to rank
+authors within the core team while non-core team members were listed
+alphabetically.
+
+Our motivation to divide contributors that way was to highlight authors who took
+a more involved part in the creation of the paper itself. 
+Everybody in the
+community could join this group at any time to give feedback, help organizing or
+chair a meeting.
+
+## Authors
+
+We defined as author anyone who:
+
+- Gave approval of the version of the manuscript to be published,
+
+- Had their names and details listed in our contributors spreadsheet.
+
+Authors include 2 mutually exclusive groups with different ranking systems:
+
+- Core team authors come first,
+
+- Non-core team authors come after that.
+
+The last author is a consortium author name (“Brainhack community”) to
+acknowledge that more people than those listed in the author list have been
+involved in the building of this community and the organizing of Brainhack
+events.
+
+### Non-core team
+
+- Order: alphabetical
+
+Ticked any of the following “boxes” in our contribution list:
+
+- participated in event (e.g: led or joined a hackathon project)
+- organized or helped organizing an event
+- taught at event (e.g: traintrack)
+- attended any general group meetings of this project
+
+### Core team
+
+- Order: ranked
+
+Ticked any of the following “boxes” in our contribution list:
+
+- attended core group meetings
+- led general group meetings
+- led core group meetings
+- prepared meeting venue (zoom) (for any meeting)
+- prepared meeting agenda
+- managed meeting times (doodle)
+- took notes in meeting
+- monitored chat in meeting
+- prepared or emailed meeting summaries to the group
+- contributed to paper brainstorm
+- attended section group meetings
+- wrote original section content
+- revised for a section
+- created figures
+- created tables, glossary
+- gathered data
+- paper editing, reviewing and revision
+- performed master editing
+- performed internal review
+- responded to internal review and revised manuscript
+- jupyter book
+- prepared / gave presentations at Brainhack global events
+- preprint dissemination
+
+#### Ranking method "WIP"
+
+Agreement on a ranking for the core team will be made in
+“bottom-up” fashion starting at the “sub-team” level and then aggregating the
+results. Ranking will also be informed by the “contributors” boxes they have
+ticked in the contributors spreadsheet. 
+
+## Acknowledgements
+
+The authors of “significant” comments on the preprints can be mentioned in the
+acknowledgments. Order: Alphabetical

--- a/brainhack_book/authorship-agreement.md
+++ b/brainhack_book/authorship-agreement.md
@@ -50,7 +50,7 @@ Authors include 2 mutually exclusive groups with different ranking systems:
 
 The last author is a consortium author name (“Brainhack community”) to
 acknowledge that more people than those listed in the author list have been
-involved in the building of this community and the organizing of Brainhack
+involved in the building of this community and the organization of Brainhack
 events.
 
 ### Non-core team

--- a/brainhack_book/authorship-agreement.md
+++ b/brainhack_book/authorship-agreement.md
@@ -30,9 +30,7 @@ alphabetically.
 
 Our motivation to divide contributors that way was to highlight authors who took
 a more involved part in the creation of the paper itself. 
-Everybody in the
-community could join this group at any time to give feedback, help organizing or
-chair a meeting.
+Everybody in the community could join this group at any time to actively contribute content, help writing, creating figures, give feedback, help organizing or chair a meeting.
 
 ## Authors
 


### PR DESCRIPTION
This is the equivalent of the current version of the google doc.

Not added in the TOC yaml as I am not sure where this will go.