### PR TITLE
Temporary fix for build with jupyter-book==0.10.2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,5 +15,5 @@ dependencies:
   - ghp-import
   - matplotlib
   - pip:
-    - jupyter-book>=0.7.0b
+    - jupyter-book==0.10.2
     - osfclient>=0.0.4


### PR DESCRIPTION
Here is a temporary fix that addresses #75 

I changed the jupyter-book version to be 0.10.2 in the `environment.yml` file, which is the last known version to build successfully with this current format. 

Let's keep the issue open until we decide whether or not to keep with version 0.10.2 or migrate from the previous format.